### PR TITLE
workarround to timeout initialising rexray #389

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vagrant
 roles/
 Volumes
+ansible.cfg

--- a/ansible_rexray.yml
+++ b/ansible_rexray.yml
@@ -1,7 +1,7 @@
 ---
 
 - hosts: all
-  sudo: yes
+  become: yes
   roles:
   - { role: emccode.rexray,
       rexray_storage_drivers: [virtualbox],

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: reload systemd
+  command: systemctl daemon-reload
+
 - name: restart rexray
   service:
     name: rexray

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: reload systemd
   command: systemctl daemon-reload
+  when: systemctl.stat.exists == True
 
 - name: restart rexray
   service:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -6,3 +6,13 @@
 - name: Add rexray config file
   template: src=config.yml.j2 dest=/etc/rexray/config.yml mode=0755 owner=root group=root
   notify: restart rexray
+
+- name: Create systemctl override config file directory
+  file: path=/etc/systemd/system/rexray.service.d/ state=directory mode=0755 owner=root group=root
+
+- name: Add rexray config file
+  template: src=override.conf dest=/etc/systemd/system/rexray.service.d/override.conf mode=0755 owner=root group=root
+  notify:
+    - reload systemd
+    - restart rexray
+  

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,8 +8,13 @@
 
 - include: config.yml
 
+- name: do we uses systemctl
+  stat: path=/bin/systemctl
+  register: systemctl
+
 - name: ensure systemd is reloaded
   command: systemctl daemon-reload
+  when: systemctl.stat.exists == True
   
 - name: ensure rexray is running
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,9 @@
 
 - include: config.yml
 
+- name: ensure systemd is reloaded
+  command: systemctl daemon-reload
+  
 - name: ensure rexray is running
   service:
     name: rexray

--- a/templates/override.conf
+++ b/templates/override.conf
@@ -1,0 +1,4 @@
+[Service]
+Restart=always
+StartLimitIntervalSec=100
+StartLimitBurst=10

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,6 +1,6 @@
 ---
 - hosts: localhost
   remote_user: root
-  sudo: true
+  become: true
   roles:
     - ansible-role-rexray


### PR DESCRIPTION
Thanks to @byrnedo I wanted to complete the ansible rexray role to add the `/etc/systemd/system/rexray.service.d/override.conf` file in order to let rexray correctly initialising on all nodes.

cf: https://github.com/codedellemc/rexray/issues/389#issuecomment-230411337

sébastien